### PR TITLE
Add 'clear all' group action

### DIFF
--- a/src/pages/lists/lists.ts
+++ b/src/pages/lists/lists.ts
@@ -44,7 +44,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
           <tr>
             <th>#</th>
             <th>Delegate</th>
-            <th class="text-right">Actions</th>
+            <th class="text-right">Actions (<a href="javascript:void(0);" (click)="clearAll()">clear all</a>)</th>
           </tr>
         </thead>
         <tbody>
@@ -335,6 +335,11 @@ export class ListsPageComponent implements OnInit,OnDestroy {
 
   removeDelegate(delegateId: number){
     this.delegateList.splice(delegateId, 1)
+    this.addList(this.listId)
+  }
+
+  clearAll(){
+    this.delegateList = []
     this.addList(this.listId)
   }
 


### PR DESCRIPTION
Allows easy clearing of the delegate list:

> Actions (_clear all_)

- [x] Tested on macOS
- [x] State is saved when the application is restarted 