### PR TITLE
Prevent title from changing to the page name

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <title>Fair Chair</title>
     <script>document.write('<base href="' + document.location + '" />');</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <link rel="stylesheet" href="css/materia.min.css"></link>


### PR DESCRIPTION
This prevents the application from having its title change to 'home-page', 'lists-page', etc. and instead uses the title 'Fair Chair'. This pull request is meant to be more of a request-for-comments rather than an actual fix. The question being:

Do we want the title to stay 'Fair Chair', or do we want it to be dynamic, e.g.: 'Fair Chair | List', when on the list page and 'Fair Chair' when on the home page?

Changes will be made appropriately depending on the decision.